### PR TITLE
지도 중심 및 줌 업데이트 로직 분리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,32 @@ function getZoomLevelForDistance(distance) {
   return 15; // 1.2km 미만
 }
 
+function updateMapCenterAndZoom(map, start, end) {
+  const hasStart = start?.lat && start?.lng;
+  const hasEnd = end?.lat && end?.lng;
+  let center = null;
+
+  if (hasStart && hasEnd) {
+    center = {
+      lat: (start.lat + end.lat) / 2,
+      lng: (start.lng + end.lng) / 2,
+    };
+    map.setCenter(new window.naver.maps.LatLng(center.lat, center.lng));
+    const distance = haversine(start.lat, start.lng, end.lat, end.lng);
+    map.setZoom(getZoomLevelForDistance(distance));
+  } else if (hasStart) {
+    center = { lat: start.lat, lng: start.lng };
+    map.setCenter(new window.naver.maps.LatLng(center.lat, center.lng));
+    map.setZoom(15);
+  } else if (hasEnd) {
+    center = { lat: end.lat, lng: end.lng };
+    map.setCenter(new window.naver.maps.LatLng(center.lat, center.lng));
+    map.setZoom(15);
+  }
+
+  return center;
+}
+
 export default function App() {
   const { startLocation, endLocation, waypoints, setStartLocation } = useContext(RouteContext);
   const { location: userLocation, error: locationError } = useCurrentLocation();
@@ -57,30 +83,14 @@ export default function App() {
       setInitialLocationSet(true);
     }
   }, [userLocation, startLocation, initialLocationSet, setStartLocation]);
-  
+
   useEffect(() => {
     if (!mapInstance) return;
-    const hasStart = startLocation?.lat && startLocation?.lng;
-    const hasEnd = endLocation?.lat && endLocation?.lng;
+    if (!startLocation && !endLocation) return;
 
-    if (hasStart && hasEnd) {
-        const centerLat = (startLocation.lat + endLocation.lat) / 2;
-        const centerLng = (startLocation.lng + endLocation.lng) / 2;
-        mapInstance.setCenter(new window.naver.maps.LatLng(centerLat, centerLng));
-        const distance = haversine(startLocation.lat, startLocation.lng, endLocation.lat, endLocation.lng);
-        const zoom = getZoomLevelForDistance(distance);
-        mapInstance.setZoom(zoom);
-    } else if (hasStart) {
-        setMapCenter({ lat: startLocation.lat, lng: startLocation.lng });
-        mapInstance.setZoom(15);
-    } else if (hasEnd) {
-        setMapCenter({ lat: endLocation.lat, lng: endLocation.lng });
-        mapInstance.setZoom(15);
-    }
-    
-    // ✨ [문제 해결] 출발지가 있으면 statsCenter를 설정하고, 없으면 null로 초기화합니다.
-    setStatsCenter(hasStart ? startLocation : null);
-
+    const center = updateMapCenterAndZoom(mapInstance, startLocation, endLocation);
+    if (center) setMapCenter(center);
+    setStatsCenter(startLocation ?? null);
   }, [startLocation, endLocation, mapInstance]);
 
   useEffect(() => { if (locationError) console.error(locationError); }, [locationError]);


### PR DESCRIPTION
## 요약
- 지도 중심/줌 계산을 전담하는 `updateMapCenterAndZoom` 함수 추가
- 출발/도착 좌표 감지 시 새 함수 호출하도록 `useEffect` 단순화

## 테스트
- `npm test` (실패: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5542f4604832f960afb3eedc1755e