### PR TITLE
refactor: add reusable script loader

### DIFF
--- a/src/components/MapLoader.jsx
+++ b/src/components/MapLoader.jsx
@@ -1,6 +1,47 @@
 // src/components/MapLoader.jsx
 import { useEffect, useState } from "react";
 
+function loadScript({ src, callback, async = true, defer = true, onLoad, onError }) {
+  return new Promise((resolve, reject) => {
+    const base = src.split("?")[0];
+    const existing = document.querySelector(`script[src^="${base}"]`);
+
+    if (callback) {
+      window[callback] = () => {
+        onLoad?.();
+        resolve();
+        delete window[callback];
+      };
+    }
+
+    if (existing) {
+      if (!callback) existing.addEventListener("load", () => {
+        onLoad?.();
+        resolve();
+      });
+      existing.addEventListener("error", (e) => {
+        onError?.(e);
+        reject(e);
+      });
+      return;
+    }
+
+    const s = document.createElement("script");
+    s.src = src;
+    if (async) s.async = true;
+    if (defer) s.defer = true;
+    if (!callback) s.addEventListener("load", () => {
+      onLoad?.();
+      resolve();
+    });
+    s.addEventListener("error", (e) => {
+      onError?.(e);
+      reject(e);
+    });
+    document.head.appendChild(s);
+  });
+}
+
 export default function MapLoader({ children }) {
   const [loaded, setLoaded] = useState(false);
 
@@ -8,67 +49,24 @@ export default function MapLoader({ children }) {
     let alive = true; // 언마운트 후 setState 방지용
 
     /* ───────────── 1) 네이버 지도 로더 ───────────── */
-    const loadNaver = () =>
-      new Promise((resolve, reject) => {
-        if (window.naver && window.naver.maps) return resolve(); // 이미 있음
-
-        const base = "https://oapi.map.naver.com/openapi/v3/maps.js";
-        const existing = document.querySelector(`script[src^="${base}"]`);
-        if (existing) {
-          existing.addEventListener("load", resolve);
-          existing.addEventListener("error", reject);
-          return;
-        }
-
-        const s = document.createElement("script");
-        s.src = `${base}?ncpKeyId=${import.meta.env.VITE_NAVER_KEY_ID}`;
-        s.async = true;
-        s.defer = true;
-        s.addEventListener("load", () => {
-          console.log("✅ 네이버 지도 스크립트 로드 완료");
-          resolve();
-        });
-        s.addEventListener("error", (e) => {
-          console.error("❌ 네이버 지도 인증 실패", e);
-          reject(e);
-        });
-        document.head.appendChild(s);
-      });
+    const loadNaver = () => {
+      if (window.naver && window.naver.maps) return Promise.resolve();
+      const src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${import.meta.env.VITE_NAVER_KEY_ID}`;
+      return loadScript({ src });
+    };
 
     /* ───────────── 2) Google Maps 로더 ───────────── */
-    const loadGoogle = () =>
-      new Promise((resolve, reject) => {
-        if (window.google && window.google.maps) return resolve(); // 이미 있음
-
-        const base = "https://maps.googleapis.com/maps/api/js";
-        const params =
-          `key=${import.meta.env.VITE_GOOGLE_KEY}` +
-          `&libraries=places` +
-          `&callback=__initGoogle` +
-          `&loading=async`;
-
-        const existing = document.querySelector(`script[src^="${base}"]`);
-        if (existing) {
-          existing.addEventListener("load", resolve);
-          existing.addEventListener("error", reject);
-          return;
-        }
-
-        window.__initGoogle = () => {
-          resolve();
-          delete window.__initGoogle;
-        };
-
-        const s = document.createElement("script");
-        s.src = `${base}?${params}`;
-        s.async = true;
-        s.defer = true;
-        s.addEventListener("error", (e) => {
-          console.error("❌ Google Maps 스크립트 로드 실패", e);
-          reject(e);
-        });
-        document.head.appendChild(s);
-      });
+    const loadGoogle = () => {
+      if (window.google && window.google.maps) return Promise.resolve();
+      const callback = "__initGoogle";
+      const src =
+        "https://maps.googleapis.com/maps/api/js?" +
+        `key=${import.meta.env.VITE_GOOGLE_KEY}` +
+        `&libraries=places` +
+        `&callback=${callback}` +
+        `&loading=async`;
+      return loadScript({ src, callback });
+    };
 
     /* ───────────── 3) 둘 다 로드될 때까지 대기 ───────────── */
     Promise.all([loadNaver(), loadGoogle()])


### PR DESCRIPTION
## Summary
- refactor Naver and Google map loaders to use shared loadScript helper
- keep existing Promise.all behavior for simultaneous script loading

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c558f21244832fad2341610aa3259b