### PR TITLE
fix: ensure loadScript resolves reliably

### DIFF
--- a/src/components/MapLoader.jsx
+++ b/src/components/MapLoader.jsx
@@ -7,7 +7,9 @@ function loadScript({ src, callback, async = true, defer = true, onLoad, onError
     let script = document.querySelector(`script[src^="${base}"]`);
 
     const finish = () => {
+      if (script?.dataset.loaded === "true") return;
       script?.setAttribute("data-loaded", "true");
+      script?.removeEventListener("load", finish);
       onLoad?.();
       resolve();
     };
@@ -19,7 +21,7 @@ function loadScript({ src, callback, async = true, defer = true, onLoad, onError
         return;
       }
 
-      if (!callback) script.addEventListener("load", finish);
+      script.addEventListener("load", finish);
       script.addEventListener("error", (e) => {
         onError?.(e);
         reject(e);
@@ -29,7 +31,7 @@ function loadScript({ src, callback, async = true, defer = true, onLoad, onError
       script.src = src;
       if (async) script.async = true;
       if (defer) script.defer = true;
-      if (!callback) script.addEventListener("load", finish);
+      script.addEventListener("load", finish);
       script.addEventListener("error", (e) => {
         onError?.(e);
         reject(e);
@@ -67,8 +69,7 @@ export default function MapLoader({ children }) {
         "https://maps.googleapis.com/maps/api/js?" +
         `key=${import.meta.env.VITE_GOOGLE_KEY}` +
         `&libraries=places` +
-        `&callback=${callback}` +
-        `&loading=async`;
+        `&callback=${callback}`;
       return loadScript({ src, callback });
     };
 


### PR DESCRIPTION
## Summary
- call load event listener as fallback when loading external scripts
- remove async loading param from Google Maps loader to ensure callback firing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c55c0d5554832fa308075f6bb0d4f2