### PR TITLE
feat: add useMarkers hook and refactor marker components

### DIFF
--- a/src/components/DdarungiMarkers.jsx
+++ b/src/components/DdarungiMarkers.jsx
@@ -1,20 +1,18 @@
 // src/components/DdarungiMarkers.jsx
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
+import useMarkers from "../hooks/useMarkers";
 import haversine from "../utils/haversine";
 import { NEARBY_RADIUS_METERS } from "../utils/constants";
 
 export default function DdarungiMarkers({ map, center, stations }) {
-  // ✨ [문제 해결] 생성된 마커들을 저장할 '보관함'(useRef)을 만듭니다.
-  const markersRef = useRef([]);
+  const setMarkers = useMarkers(map);
 
   useEffect(() => {
-    // 1. (가장 중요) 새로운 마커를 그리기 전에, 보관함에 있던 모든 마커를 지도에서 제거합니다.
-    markersRef.current.forEach(marker => marker.setMap(null));
-    markersRef.current = []; // 보관함 배열을 비웁니다.
+    if (!map || !center || !stations) {
+      setMarkers([]);
+      return;
+    }
 
-    // 지도, 중심점, 대여소 데이터가 없으면 아무 작업도 하지 않습니다.
-    if (!map || !center || !stations) return;
-    
     const newMarkers = [];
     stations.forEach((station) => {
       const lat = parseFloat(station.stationLatitude);
@@ -26,7 +24,6 @@ export default function DdarungiMarkers({ map, center, stations }) {
       if (dist <= NEARBY_RADIUS_METERS) {
         const marker = new window.naver.maps.Marker({
           position: new window.naver.maps.LatLng(lat, lng),
-          map,
           title: station.stationName,
           icon: {
             content: `<div style="background-color: #4CAF50; border-radius: 50%; width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; color: white; font-size: 14px; font-weight: bold; border: 2px solid white; box-shadow: 0 2px 4px rgba(0,0,0,0.3);">🚲</div>`,
@@ -37,10 +34,8 @@ export default function DdarungiMarkers({ map, center, stations }) {
       }
     });
 
-    // 2. 새로 생성된 마커 목록을 보관함에 저장하여, 다음 실행 때 제거할 수 있도록 합니다.
-    markersRef.current = newMarkers;
-    
-  }, [map, center, stations]); // map, center, stations가 변경될 때마다 이 로직이 다시 실행됩니다.
+    setMarkers(newMarkers);
+  }, [map, center, stations, setMarkers]);
 
   return null;
 }

--- a/src/components/RouteStationMarkers.jsx
+++ b/src/components/RouteStationMarkers.jsx
@@ -1,29 +1,31 @@
 // src/components/RouteStationMarkers.jsx
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
+import useMarkers from "../hooks/useMarkers";
 import haversine from "../utils/haversine";
 
-const STATION_SEARCH_RADIUS = 300; 
+const STATION_SEARCH_RADIUS = 300;
 
 export default function RouteStationMarkers({ map, selectedRoute, allStations }) {
-    // ✨ [문제 해결] 생성된 마커들을 저장할 '보관함'(useRef)을 만듭니다.
-    const markersRef = useRef([]);
+    const setMarkers = useMarkers(map);
 
     useEffect(() => {
-        // 1. (가장 중요) 새로운 마커를 그리기 전에, 보관함에 있던 모든 마커를 지도에서 제거합니다.
-        markersRef.current.forEach(marker => marker.setMap(null));
-        markersRef.current = []; // 보관함 배열을 비웁니다.
-
-        if (!map || !selectedRoute?.summary?.subPath || !allStations) return;
+        if (!map || !selectedRoute?.summary?.subPath || !allStations) {
+            setMarkers([]);
+            return;
+        }
 
         const bikeSegments = selectedRoute.summary.subPath.filter(path => path.trafficType === 4);
-        if (bikeSegments.length === 0) return;
+        if (bikeSegments.length === 0) {
+            setMarkers([]);
+            return;
+        }
 
         const startStationName = bikeSegments[0].startName;
         const endStationName = bikeSegments[bikeSegments.length - 1].endName;
-        
+
         const startStation = allStations.find(s => s.stationName.includes(startStationName));
         const endStation = allStations.find(s => s.stationName.includes(endStationName));
-        
+
         const pointsToSearch = [];
         if (startStation) pointsToSearch.push({ station: startStation, type: 'start' });
         if (endStation && startStation?.stationId !== endStation?.stationId) {
@@ -51,7 +53,6 @@ export default function RouteStationMarkers({ map, selectedRoute, allStations })
                     const color = type === 'start' ? '#3498db' : '#e74c3c';
                     const marker = new window.naver.maps.Marker({
                         position: new window.naver.maps.LatLng(lat, lng),
-                        map,
                         title: s.stationName,
                         icon: {
                             content: `<div style="background-color: ${color}; border-radius: 50%; width: 22px; height: 22px; display: flex; align-items: center; justify-content: center; color: white; font-size: 12px; border: 2px solid white; box-shadow: 0 2px 4px rgba(0,0,0,0.3);">🚲</div>`,
@@ -65,10 +66,8 @@ export default function RouteStationMarkers({ map, selectedRoute, allStations })
             });
         });
 
-        // 2. 새로 생성된 마커 목록을 보관함에 저장하여, 다음 실행 때 제거할 수 있도록 합니다.
-        markersRef.current = newMarkers;
-
-    }, [map, selectedRoute, allStations]);
+        setMarkers(newMarkers);
+    }, [map, selectedRoute, allStations, setMarkers]);
 
     return null;
 }

--- a/src/hooks/useMarkers.js
+++ b/src/hooks/useMarkers.js
@@ -1,0 +1,30 @@
+import { useRef, useEffect } from "react";
+
+export default function useMarkers(map, initialMarkers = []) {
+  const markersRef = useRef([]);
+  const mapRef = useRef(map);
+
+  useEffect(() => {
+    mapRef.current = map;
+    // 지도 변경 시, 현재 저장된 마커들을 새 지도에 다시 표시합니다.
+    markersRef.current.forEach(marker => marker.setMap(map));
+  }, [map]);
+
+  const setMarkers = (nextMarkers = []) => {
+    // 기존 마커 제거
+    markersRef.current.forEach(marker => marker.setMap(null));
+    markersRef.current = [];
+
+    // 새 마커를 지도에 추가
+    if (mapRef.current) {
+      nextMarkers.forEach(marker => marker.setMap(mapRef.current));
+      markersRef.current = nextMarkers;
+    }
+  };
+
+  useEffect(() => {
+    setMarkers(initialMarkers);
+  }, [initialMarkers]);
+
+  return setMarkers;
+}


### PR DESCRIPTION
## Summary
- add reusable `useMarkers` hook for managing marker lifecycles on the map
- refactor `DdarungiMarkers` and `RouteStationMarkers` to use `useMarkers`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c563d126e4832f81322c0c6a7d5637