### PR TITLE
Prioritize hybrid routes before slicing results

### DIFF
--- a/src/utils/routeCalculator.js
+++ b/src/utils/routeCalculator.js
@@ -8,6 +8,7 @@ import { ROUTE_COLORS } from "./routeColors";
 import { processOdsayPath } from "./routeCalculator/processOdsayPath";
 import { createBikeFirst } from "./routeCalculator/createBikeFirst";
 import { createBikeLast } from "./routeCalculator/createBikeLast";
+import { prioritizeRoutes } from "./routeCalculator/prioritizeRoutes.js";
 import {
   findNearestStation,
   getTotalTime,
@@ -32,7 +33,7 @@ export async function calculateCombinedRoutes({ start, end, waypoints, stations 
     console.error("경로 계산 중 오류 발생:", error);
   }
 
-  return finalRoutes.slice(0, 5);
+  return prioritizeRoutes(finalRoutes).slice(0, 5);
 }
 
 async function calculateWaypointRoutes({ start, end, viaPoints }) {
@@ -168,6 +169,7 @@ async function calculateDirectRoutes({ start, end, stations }) {
     allCandidates.push(...currentCandidates);
     if (sortCandidates(removeDuplicates(allCandidates)).length >= 5) break;
   }
-  return sortCandidates(removeDuplicates(allCandidates));
+  const sortedCandidates = sortCandidates(removeDuplicates(allCandidates));
+  return prioritizeRoutes(sortedCandidates);
 }
 

--- a/src/utils/routeCalculator/prioritizeRoutes.js
+++ b/src/utils/routeCalculator/prioritizeRoutes.js
@@ -1,0 +1,23 @@
+export function prioritizeRoutes(routes) {
+  if (!Array.isArray(routes)) return [];
+
+  const hybridRoutes = [];
+  const transitOnlyRoutes = [];
+  const bikeOnlyRoutes = [];
+
+  for (const route of routes) {
+    const subPaths = route?.summary?.subPath || [];
+    const hasBike = subPaths.some(path => path?.trafficType === 4);
+    const hasNonBike = subPaths.some(path => path?.trafficType !== 4);
+
+    if (hasBike && hasNonBike) {
+      hybridRoutes.push(route);
+    } else if (hasBike) {
+      bikeOnlyRoutes.push(route);
+    } else {
+      transitOnlyRoutes.push(route);
+    }
+  }
+
+  return [...hybridRoutes, ...transitOnlyRoutes, ...bikeOnlyRoutes];
+}

--- a/tests/routePrioritization.test.mjs
+++ b/tests/routePrioritization.test.mjs
@@ -1,0 +1,19 @@
+import assert from "assert";
+import { prioritizeRoutes } from "../src/utils/routeCalculator/prioritizeRoutes.js";
+
+const routes = [
+  { id: "transit-1", summary: { subPath: [{ trafficType: 1 }, { trafficType: 3 }] } },
+  { id: "hybrid-1", summary: { subPath: [{ trafficType: 4 }, { trafficType: 1 }] } },
+  { id: "bike-1", summary: { subPath: [{ trafficType: 4 }] } },
+  { id: "transit-2", summary: { subPath: [{ trafficType: 2 }] } },
+  { id: "hybrid-2", summary: { subPath: [{ trafficType: 4 }, { trafficType: 2 }] } },
+  { id: "bike-2", summary: { subPath: [{ trafficType: 4 }] } },
+];
+
+const prioritized = prioritizeRoutes(routes).slice(0, 5);
+const ids = prioritized.map(route => route.id);
+
+assert.deepStrictEqual(ids.slice(0, 2), ["hybrid-1", "hybrid-2"]);
+assert.deepStrictEqual(ids.slice(2), ["transit-1", "transit-2", "bike-1"]);
+
+console.log("복합 경로 우선 정렬 테스트 통과");


### PR DESCRIPTION
## Summary
- prioritize mixed bike transit routes ahead of other options before truncating results
- expose the prioritization logic in a standalone helper for reuse
- add a unit test ensuring hybrid routes always surface first when present

## Testing
- node tests/routePrioritization.test.mjs
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0ca644d38832f98f96a3438327351