### PR TITLE
Adjust direct route iteration for hybrid detection

### DIFF
--- a/src/utils/routeCalculator.js
+++ b/src/utils/routeCalculator.js
@@ -167,7 +167,19 @@ async function calculateDirectRoutes({ start, end, stations }) {
     }
 
     allCandidates.push(...currentCandidates);
-    if (sortCandidates(removeDuplicates(allCandidates)).length >= 5) break;
+
+    const sortedCandidates = sortCandidates(removeDuplicates(allCandidates));
+    allCandidates = sortedCandidates;
+
+    const hasMixedRoute = sortedCandidates.some(candidate => {
+      const subPaths = candidate?.summary?.subPath || [];
+      const hasBike = subPaths.some(path => path?.trafficType === 4);
+      const hasNonBike = subPaths.some(path => path?.trafficType !== 4);
+      return hasBike && hasNonBike;
+    });
+
+    const isLastAttempt = attempt >= MAX_ATTEMPTS;
+    if (hasMixedRoute || isLastAttempt) break;
   }
   const sortedCandidates = sortCandidates(removeDuplicates(allCandidates));
   return prioritizeRoutes(sortedCandidates);


### PR DESCRIPTION
## Summary
- continue iterating direct-route attempts until a hybrid (bike + other) path is found or attempts are exhausted
- reuse sorted, de-duplicated candidates when checking for hybrid availability to keep prioritization consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0cdce3a10832f89b350d238be9419