### PR TITLE
Filter out transit-only routes from results

### DIFF
--- a/src/utils/routeCalculator/prioritizeRoutes.js
+++ b/src/utils/routeCalculator/prioritizeRoutes.js
@@ -2,7 +2,6 @@ export function prioritizeRoutes(routes) {
   if (!Array.isArray(routes)) return [];
 
   const hybridRoutes = [];
-  const transitOnlyRoutes = [];
   const bikeOnlyRoutes = [];
 
   for (const route of routes) {
@@ -10,14 +9,16 @@ export function prioritizeRoutes(routes) {
     const hasBike = subPaths.some(path => path?.trafficType === 4);
     const hasNonBike = subPaths.some(path => path?.trafficType !== 4);
 
-    if (hasBike && hasNonBike) {
+    if (!hasBike) {
+      continue;
+    }
+
+    if (hasNonBike) {
       hybridRoutes.push(route);
     } else if (hasBike) {
       bikeOnlyRoutes.push(route);
-    } else {
-      transitOnlyRoutes.push(route);
     }
   }
 
-  return [...hybridRoutes, ...transitOnlyRoutes, ...bikeOnlyRoutes];
+  return [...hybridRoutes, ...bikeOnlyRoutes];
 }


### PR DESCRIPTION
## Summary
- filter waypoint and direct route candidates to ensure they include at least one bike segment
- update candidate aggregation to drop public-transit-only paths before prioritization
- adjust route prioritization to return only hybrid or bike-only options

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d0dbbaecf4832f9b9ac794eef655e9